### PR TITLE
fix(spark): fix the indentation rendering of examples

### DIFF
--- a/src/main/java/io/kestra/plugin/spark/JarSubmit.java
+++ b/src/main/java/io/kestra/plugin/spark/JarSubmit.java
@@ -32,20 +32,20 @@ import static io.kestra.core.utils.Rethrow.*;
             namespace: company.team
 
             inputs:
-                - id: file
-                  type: FILE
+              - id: file
+                type: FILE
 
             tasks:
-                - id: jar_submit
-                  type: io.kestra.plugin.spark.JarSubmit
-                  containerImage: bitnami/spark
-                  taskRunner:
-                      type: io.kestra.plugin.scripts.runner.docker.Docker
-                      networkMode: host
-                      user: root
-                  master: spark://localhost:7077
-                  mainResource: {{ inputs.file }}
-                  mainClass: spark.samples.App"""
+              - id: jar_submit
+                type: io.kestra.plugin.spark.JarSubmit
+                containerImage: bitnami/spark
+                taskRunner:
+                    type: io.kestra.plugin.scripts.runner.docker.Docker
+                    networkMode: host
+                    user: root
+                master: spark://localhost:7077
+                mainResource: {{ inputs.file }}
+                mainClass: spark.samples.App"""
         )
     }
 )

--- a/src/main/java/io/kestra/plugin/spark/JarSubmit.java
+++ b/src/main/java/io/kestra/plugin/spark/JarSubmit.java
@@ -28,25 +28,24 @@ import static io.kestra.core.utils.Rethrow.*;
         @Example(
             full = true,
             code = """
-                id: spark_jar_submit
-                namespace: company.team
+            id: spark_jar_submit
+            namespace: company.team
 
-                inputs:
-                  - id: file
-                    type: FILE
+            inputs:
+                - id: file
+                type: FILE
 
-                tasks:
-                  - id: jar_submit
-                    type: io.kestra.plugin.spark.JarSubmit
-                    containerImage: bitnami/spark
-                    taskRunner:
-                      type: io.kestra.plugin.scripts.runner.docker.Docker
-                      networkMode: host
-                      user: root
-                    master: spark://localhost:7077
-                    mainResource: {{ inputs.file }}
-                    mainClass: spark.samples.App
-                """
+            tasks:
+                - id: jar_submit
+                type: io.kestra.plugin.spark.JarSubmit
+                containerImage: bitnami/spark
+                taskRunner:
+                    type: io.kestra.plugin.scripts.runner.docker.Docker
+                    networkMode: host
+                    user: root
+                master: spark://localhost:7077
+                mainResource: {{ inputs.file }}
+                mainClass: spark.samples.App"""
         )
     }
 )

--- a/src/main/java/io/kestra/plugin/spark/JarSubmit.java
+++ b/src/main/java/io/kestra/plugin/spark/JarSubmit.java
@@ -44,7 +44,7 @@ import static io.kestra.core.utils.Rethrow.*;
                     networkMode: host
                     user: root
                 master: spark://localhost:7077
-                mainResource: {{ inputs.file }}
+                mainResource: "{{ inputs.file }}"
                 mainClass: spark.samples.App"""
         )
     }

--- a/src/main/java/io/kestra/plugin/spark/JarSubmit.java
+++ b/src/main/java/io/kestra/plugin/spark/JarSubmit.java
@@ -33,19 +33,19 @@ import static io.kestra.core.utils.Rethrow.*;
 
             inputs:
                 - id: file
-                type: FILE
+                  type: FILE
 
             tasks:
                 - id: jar_submit
-                type: io.kestra.plugin.spark.JarSubmit
-                containerImage: bitnami/spark
-                taskRunner:
-                    type: io.kestra.plugin.scripts.runner.docker.Docker
-                    networkMode: host
-                    user: root
-                master: spark://localhost:7077
-                mainResource: {{ inputs.file }}
-                mainClass: spark.samples.App"""
+                  type: io.kestra.plugin.spark.JarSubmit
+                  containerImage: bitnami/spark
+                  taskRunner:
+                      type: io.kestra.plugin.scripts.runner.docker.Docker
+                      networkMode: host
+                      user: root
+                  master: spark://localhost:7077
+                  mainResource: {{ inputs.file }}
+                  mainClass: spark.samples.App"""
         )
     }
 )

--- a/src/main/java/io/kestra/plugin/spark/PythonSubmit.java
+++ b/src/main/java/io/kestra/plugin/spark/PythonSubmit.java
@@ -56,10 +56,7 @@ import static io.kestra.core.utils.Rethrow.throwBiConsumer;
 
 
                       if __name__ == "__main__":
-                          spark = SparkSession \
-                              .builder \
-                              .appName("PythonPi") \
-                              .getOrCreate()
+                          spark = SparkSession.builder.appName("PythonPi").getOrCreate()
 
                           partitions = int(sys.argv[1]) if len(sys.argv) > 1 else 2
                           n = 100000 * partitions

--- a/src/main/java/io/kestra/plugin/spark/RSubmit.java
+++ b/src/main/java/io/kestra/plugin/spark/RSubmit.java
@@ -31,26 +31,25 @@ import jakarta.validation.constraints.NotNull;
         @Example(
             full = true,
             code = """
-                id: spark_r_submit
-                namespace: company.team
+            id: spark_r_submit
+            namespace: company.team
 
-                tasks:
-                  - id: r_submit
-                    type: io.kestra.plugin.spark.RSubmit
-                    containerImage: bitnami/spark
-                    taskRunner:
-                      type: io.kestra.plugin.scripts.runner.docker.Docker
-                      networkMode: host
-                      user: root
-                    master: spark://localhost:7077
-                    mainScript: |
-                      library(SparkR, lib.loc = c(file.path(Sys.getenv("SPARK_HOME"), "R", "lib")))
-                      sparkR.session()
+            tasks:
+                - id: r_submit
+                type: io.kestra.plugin.spark.RSubmit
+                containerImage: bitnami/spark
+                taskRunner:
+                    type: io.kestra.plugin.scripts.runner.docker.Docker
+                    networkMode: host
+                    user: root
+                master: spark://localhost:7077
+                mainScript: |
+                    library(SparkR, lib.loc = c(file.path(Sys.getenv("SPARK_HOME"), "R", "lib")))
+                    sparkR.session()
 
-                      print("The SparkR session has initialized successfully.")
+                    print("The SparkR session has initialized successfully.")
 
-                      sparkR.stop()
-                """
+                    sparkR.stop()"""
         )
     }
 )

--- a/src/main/java/io/kestra/plugin/spark/RSubmit.java
+++ b/src/main/java/io/kestra/plugin/spark/RSubmit.java
@@ -36,20 +36,20 @@ import jakarta.validation.constraints.NotNull;
 
             tasks:
                 - id: r_submit
-                type: io.kestra.plugin.spark.RSubmit
-                containerImage: bitnami/spark
-                taskRunner:
-                    type: io.kestra.plugin.scripts.runner.docker.Docker
-                    networkMode: host
-                    user: root
-                master: spark://localhost:7077
-                mainScript: |
-                    library(SparkR, lib.loc = c(file.path(Sys.getenv("SPARK_HOME"), "R", "lib")))
-                    sparkR.session()
+                  type: io.kestra.plugin.spark.RSubmit
+                  containerImage: bitnami/spark
+                  taskRunner:
+                      type: io.kestra.plugin.scripts.runner.docker.Docker
+                      networkMode: host
+                      user: root
+                  master: spark://localhost:7077
+                  mainScript: |
+                      library(SparkR, lib.loc = c(file.path(Sys.getenv("SPARK_HOME"), "R", "lib")))
+                      sparkR.session()
 
-                    print("The SparkR session has initialized successfully.")
+                      print("The SparkR session has initialized successfully.")
 
-                    sparkR.stop()"""
+                      sparkR.stop()"""
         )
     }
 )

--- a/src/main/java/io/kestra/plugin/spark/RSubmit.java
+++ b/src/main/java/io/kestra/plugin/spark/RSubmit.java
@@ -35,21 +35,21 @@ import jakarta.validation.constraints.NotNull;
             namespace: company.team
 
             tasks:
-                - id: r_submit
-                  type: io.kestra.plugin.spark.RSubmit
-                  containerImage: bitnami/spark
-                  taskRunner:
-                      type: io.kestra.plugin.scripts.runner.docker.Docker
-                      networkMode: host
-                      user: root
-                  master: spark://localhost:7077
-                  mainScript: |
-                      library(SparkR, lib.loc = c(file.path(Sys.getenv("SPARK_HOME"), "R", "lib")))
-                      sparkR.session()
+              - id: r_submit
+                type: io.kestra.plugin.spark.RSubmit
+                containerImage: bitnami/spark
+                taskRunner:
+                  type: io.kestra.plugin.scripts.runner.docker.Docker
+                  networkMode: host
+                  user: root
+                master: spark://localhost:7077
+                mainScript: |
+                  library(SparkR, lib.loc = c(file.path(Sys.getenv("SPARK_HOME"), "R", "lib")))
+                  sparkR.session()
 
-                      print("The SparkR session has initialized successfully.")
+                  print("The SparkR session has initialized successfully.")
 
-                      sparkR.stop()"""
+                  sparkR.stop()"""
         )
     }
 )

--- a/src/main/java/io/kestra/plugin/spark/SparkCLI.java
+++ b/src/main/java/io/kestra/plugin/spark/SparkCLI.java
@@ -38,38 +38,35 @@ import jakarta.validation.constraints.NotNull;
             namespace: company.team
 
             tasks:
-                - id: hello
-                  type: io.kestra.plugin.spark.SparkCLI
-                  inputFiles:
-                    pi.py: |
-                      import sys
-                      from random import random
-                      from operator import add
-                      from pyspark.sql import SparkSession
+              - id: hello
+                type: io.kestra.plugin.spark.SparkCLI
+                inputFiles:
+                  pi.py: |
+                    import sys
+                    from random import random
+                    from operator import add
+                    from pyspark.sql import SparkSession
 
-                      if __name__ == "__main__":
-                          spark = SparkSession \
-                              .builder \
-                              .appName("PythonPi") \
-                              .getOrCreate()
+                    if __name__ == "__main__":
+                        spark = SparkSession.builder.appName("PythonPi").getOrCreate()
 
-                          partitions = int(sys.argv[1]) if len(sys.argv) > 1 else 2
-                          n = 100000 * partitions
+                        partitions = int(sys.argv[1]) if len(sys.argv) > 1 else 2
+                        n = 100000 * partitions
 
-                          def f(_: int) -> float:
-                              x = random() * 2 - 1
-                              y = random() * 2 - 1
-                              return 1 if x ** 2 + y ** 2 <= 1 else 0
+                        def f(_: int) -> float:
+                            x = random() * 2 - 1
+                            y = random() * 2 - 1
+                            return 1 if x ** 2 + y ** 2 <= 1 else 0
 
-                          count = spark.sparkContext.parallelize(range(1, n + 1), partitions).map(f).reduce(add)
-                          print("Pi is roughly %f" % (4.0 * count / n))
+                        count = spark.sparkContext.parallelize(range(1, n + 1), partitions).map(f).reduce(add)
+                        print("Pi is roughly %f" % (4.0 * count / n))
 
-                          spark.stop()
-                  containerImage: bitnami/spark
-                  taskRunner:
-                    networkMode: host
-                  commands:
-                    - spark-submit --name Pi --master spark://localhost:7077 pi.py"""
+                        spark.stop()
+                containerImage: bitnami/spark
+                taskRunner:
+                  networkMode: host
+                commands:
+                  - spark-submit --name Pi --master spark://localhost:7077 pi.py"""
         )
     }
 )

--- a/src/main/java/io/kestra/plugin/spark/SparkCLI.java
+++ b/src/main/java/io/kestra/plugin/spark/SparkCLI.java
@@ -39,36 +39,36 @@ import jakarta.validation.constraints.NotNull;
 
             tasks:
                 - id: hello
-                type: io.kestra.plugin.spark.SparkCLI
-                inputFiles:
+                  type: io.kestra.plugin.spark.SparkCLI
+                  inputFiles:
                     pi.py: |
-                    import sys
-                    from random import random
-                    from operator import add
-                    from pyspark.sql import SparkSession
+                      import sys
+                      from random import random
+                      from operator import add
+                      from pyspark.sql import SparkSession
 
-                    if __name__ == "__main__":
-                        spark = SparkSession \
-                            .builder \
-                            .appName("PythonPi") \
-                            .getOrCreate()
+                      if __name__ == "__main__":
+                          spark = SparkSession \
+                              .builder \
+                              .appName("PythonPi") \
+                              .getOrCreate()
 
-                        partitions = int(sys.argv[1]) if len(sys.argv) > 1 else 2
-                        n = 100000 * partitions
+                          partitions = int(sys.argv[1]) if len(sys.argv) > 1 else 2
+                          n = 100000 * partitions
 
-                        def f(_: int) -> float:
-                            x = random() * 2 - 1
-                            y = random() * 2 - 1
-                            return 1 if x ** 2 + y ** 2 <= 1 else 0
+                          def f(_: int) -> float:
+                              x = random() * 2 - 1
+                              y = random() * 2 - 1
+                              return 1 if x ** 2 + y ** 2 <= 1 else 0
 
-                        count = spark.sparkContext.parallelize(range(1, n + 1), partitions).map(f).reduce(add)
-                        print("Pi is roughly %f" % (4.0 * count / n))
+                          count = spark.sparkContext.parallelize(range(1, n + 1), partitions).map(f).reduce(add)
+                          print("Pi is roughly %f" % (4.0 * count / n))
 
-                        spark.stop()
-                docker:
-                    image: bitnami/spark
+                          spark.stop()
+                  containerImage: bitnami/spark
+                  taskRunner:
                     networkMode: host
-                commands:
+                  commands:
                     - spark-submit --name Pi --master spark://localhost:7077 pi.py"""
         )
     }

--- a/src/main/java/io/kestra/plugin/spark/SparkCLI.java
+++ b/src/main/java/io/kestra/plugin/spark/SparkCLI.java
@@ -34,42 +34,42 @@ import jakarta.validation.constraints.NotNull;
             title = "Submit a PySpark job to a master node.",
             full = true,
             code = """
-                id: spark_cli
-                namespace: company.team
+            id: spark_cli
+            namespace: company.team
 
-                tasks:
-                  - id: hello
-                    type: io.kestra.plugin.spark.SparkCLI
-                    inputFiles:
-                      pi.py: |
-                        import sys
-                        from random import random
-                        from operator import add
-                        from pyspark.sql import SparkSession
+            tasks:
+                - id: hello
+                type: io.kestra.plugin.spark.SparkCLI
+                inputFiles:
+                    pi.py: |
+                    import sys
+                    from random import random
+                    from operator import add
+                    from pyspark.sql import SparkSession
 
-                        if __name__ == "__main__":
-                            spark = SparkSession \
-                                .builder \
-                                .appName("PythonPi") \
-                                .getOrCreate()
+                    if __name__ == "__main__":
+                        spark = SparkSession \
+                            .builder \
+                            .appName("PythonPi") \
+                            .getOrCreate()
 
-                            partitions = int(sys.argv[1]) if len(sys.argv) > 1 else 2
-                            n = 100000 * partitions
+                        partitions = int(sys.argv[1]) if len(sys.argv) > 1 else 2
+                        n = 100000 * partitions
 
-                            def f(_: int) -> float:
-                                x = random() * 2 - 1
-                                y = random() * 2 - 1
-                                return 1 if x ** 2 + y ** 2 <= 1 else 0
+                        def f(_: int) -> float:
+                            x = random() * 2 - 1
+                            y = random() * 2 - 1
+                            return 1 if x ** 2 + y ** 2 <= 1 else 0
 
-                            count = spark.sparkContext.parallelize(range(1, n + 1), partitions).map(f).reduce(add)
-                            print("Pi is roughly %f" % (4.0 * count / n))
+                        count = spark.sparkContext.parallelize(range(1, n + 1), partitions).map(f).reduce(add)
+                        print("Pi is roughly %f" % (4.0 * count / n))
 
-                            spark.stop()
-                    docker:
-                      image: bitnami/spark
-                      networkMode: host
-                    commands:
-                      - spark-submit --name Pi --master spark://localhost:7077 pi.py"""
+                        spark.stop()
+                docker:
+                    image: bitnami/spark
+                    networkMode: host
+                commands:
+                    - spark-submit --name Pi --master spark://localhost:7077 pi.py"""
         )
     }
 )


### PR DESCRIPTION
I don't know if this will fix the [issue](https://github.com/kestra-io/kestra/issues/8003), but I am giving it a try.