### PR TITLE
build(*): migrate bitnami docker images to apache spark

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     annotationProcessor group: "io.kestra", name: "processor", version: kestraVersion
 
     // Spark lib: must be aligned with the docker-compose-ci.yaml files and the image used in test
-    api group: 'org.apache.spark', name: 'spark-launcher_2.13', version: '3.5.7'
+    api group: 'org.apache.spark', name: 'spark-launcher_2.13', version: '4.0.1'
     compileOnly group: "io.kestra", name: "script", version: kestraVersion
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     annotationProcessor group: "io.kestra", name: "processor", version: kestraVersion
 
     // Spark lib: must be aligned with the docker-compose-ci.yaml files and the image used in test
-    api group: 'org.apache.spark', name: 'spark-launcher_2.13', version: '4.0.0-preview2'
+    api group: 'org.apache.spark', name: 'spark-launcher_2.13', version: '3.5.7'
     compileOnly group: "io.kestra", name: "script", version: kestraVersion
 }
 

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -1,6 +1,6 @@
 services:
   spark-master:
-    image: apache/spark:4.0.1-java17-r
+    image: apache/spark:4.0.1-java21-r
     container_name: spark-master
     command: [ "/opt/spark/bin/spark-class", "org.apache.spark.deploy.master.Master" ]
     ports:
@@ -9,7 +9,7 @@ services:
 
 
   spark-worker:
-    image: apache/spark:4.0.1-java17-r
+    image: apache/spark:4.0.1-java21-r
     container_name: spark-worker
     depends_on:
       - spark-master

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -1,29 +1,21 @@
-version: '3'
-
 services:
-  spark:
-    image: docker.io/bitnami/spark:3.4.1
-    environment:
-      - SPARK_MODE=master
-      - SPARK_RPC_AUTHENTICATION_ENABLED=no
-      - SPARK_RPC_ENCRYPTION_ENABLED=no
-      - SPARK_LOCAL_STORAGE_ENCRYPTION_ENABLED=no
-      - SPARK_SSL_ENABLED=no
+  spark-master:
+    image: apache/spark:3.5.7-java17-r
+    container_name: spark-master
+    command: [ "/opt/spark/bin/spark-class", "org.apache.spark.deploy.master.Master" ]
     ports:
-      - '38080:8080'
-      - '37077:7077'
+      - "38080:8080"
+      - "37077:7077"
+
 
   spark-worker:
-    image: docker.io/bitnami/spark:3.4.1
+    image: apache/spark:3.5.7-java17-r
+    container_name: spark-worker
+    depends_on:
+      - spark-master
+    command: [ "/opt/spark/bin/spark-class", "org.apache.spark.deploy.worker.Worker", "spark://spark-master:7077" ]
     environment:
-      - SPARK_MODE=worker
-      - SPARK_MASTER_URL=spark://spark:7077
-      - SPARK_WORKER_MEMORY=1G
       - SPARK_WORKER_CORES=1
-      - SPARK_RPC_AUTHENTICATION_ENABLED=no
-      - SPARK_RPC_ENCRYPTION_ENABLED=no
-      - SPARK_LOCAL_STORAGE_ENCRYPTION_ENABLED=no
-      - SPARK_SSL_ENABLED=no
+      - SPARK_WORKER_MEMORY=1G
     ports:
-      - '8081:8081'
-    hostname: localhost
+      - "8081:8081"

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -1,6 +1,6 @@
 services:
   spark-master:
-    image: apache/spark:3.5.7-java17-r
+    image: apache/spark:4.0.1-java17-r
     container_name: spark-master
     command: [ "/opt/spark/bin/spark-class", "org.apache.spark.deploy.master.Master" ]
     ports:
@@ -9,7 +9,7 @@ services:
 
 
   spark-worker:
-    image: apache/spark:3.5.7-java17-r
+    image: apache/spark:4.0.1-java17-r
     container_name: spark-worker
     depends_on:
       - spark-master

--- a/src/main/java/io/kestra/plugin/spark/AbstractSubmit.java
+++ b/src/main/java/io/kestra/plugin/spark/AbstractSubmit.java
@@ -42,7 +42,7 @@ import static io.kestra.core.utils.Rethrow.*;
 @Getter
 @NoArgsConstructor
 public abstract class AbstractSubmit extends Task implements RunnableTask<ScriptOutput> {
-    private static final String DEFAULT_IMAGE = "apache/spark:3.5.7-java17-r";
+    private static final String DEFAULT_IMAGE = "apache/spark:4.0.1-java17-r";
 
     @Schema(
         title = "Spark master hostname for the application.",

--- a/src/main/java/io/kestra/plugin/spark/AbstractSubmit.java
+++ b/src/main/java/io/kestra/plugin/spark/AbstractSubmit.java
@@ -42,7 +42,7 @@ import static io.kestra.core.utils.Rethrow.*;
 @Getter
 @NoArgsConstructor
 public abstract class AbstractSubmit extends Task implements RunnableTask<ScriptOutput> {
-    private static final String DEFAULT_IMAGE = "bitnami/spark";
+    private static final String DEFAULT_IMAGE = "apache/spark:3.5.7-java17-r";
 
     @Schema(
         title = "Spark master hostname for the application.",
@@ -89,7 +89,7 @@ public abstract class AbstractSubmit extends Task implements RunnableTask<Script
         title = "The `spark-submit` binary path."
     )
     @Builder.Default
-    private Property<String> sparkSubmitPath = Property.ofValue("spark-submit");
+    private Property<String> sparkSubmitPath = Property.ofValue("/opt/spark/bin/spark-submit");
 
     @Schema(
         title = "Additional environment variables for the current process."

--- a/src/main/java/io/kestra/plugin/spark/AbstractSubmit.java
+++ b/src/main/java/io/kestra/plugin/spark/AbstractSubmit.java
@@ -42,7 +42,7 @@ import static io.kestra.core.utils.Rethrow.*;
 @Getter
 @NoArgsConstructor
 public abstract class AbstractSubmit extends Task implements RunnableTask<ScriptOutput> {
-    private static final String DEFAULT_IMAGE = "apache/spark:4.0.1-java17-r";
+    private static final String DEFAULT_IMAGE = "apache/spark:4.0.1-java21-r";
 
     @Schema(
         title = "Spark master hostname for the application.",

--- a/src/main/java/io/kestra/plugin/spark/JarSubmit.java
+++ b/src/main/java/io/kestra/plugin/spark/JarSubmit.java
@@ -38,7 +38,6 @@ import static io.kestra.core.utils.Rethrow.*;
             tasks:
               - id: jar_submit
                 type: io.kestra.plugin.spark.JarSubmit
-                containerImage: bitnami/spark
                 taskRunner:
                     type: io.kestra.plugin.scripts.runner.docker.Docker
                     networkMode: host

--- a/src/main/java/io/kestra/plugin/spark/PythonSubmit.java
+++ b/src/main/java/io/kestra/plugin/spark/PythonSubmit.java
@@ -40,7 +40,6 @@ import static io.kestra.core.utils.Rethrow.throwBiConsumer;
                 tasks:
                   - id: python_submit
                     type: io.kestra.plugin.spark.PythonSubmit
-                    containerImage: bitnami/spark
                     taskRunner:
                       type: io.kestra.plugin.scripts.runner.docker.Docker
                       networkMode: host

--- a/src/main/java/io/kestra/plugin/spark/RSubmit.java
+++ b/src/main/java/io/kestra/plugin/spark/RSubmit.java
@@ -37,7 +37,6 @@ import jakarta.validation.constraints.NotNull;
             tasks:
               - id: r_submit
                 type: io.kestra.plugin.spark.RSubmit
-                containerImage: bitnami/spark
                 taskRunner:
                   type: io.kestra.plugin.scripts.runner.docker.Docker
                   networkMode: host

--- a/src/main/java/io/kestra/plugin/spark/SparkCLI.java
+++ b/src/main/java/io/kestra/plugin/spark/SparkCLI.java
@@ -73,7 +73,7 @@ import jakarta.validation.constraints.NotNull;
     }
 )
 public class SparkCLI extends AbstractExecScript implements RunnableTask<ScriptOutput> {
-    private static final String DEFAULT_IMAGE = "apache/spark:3.5.7-java17-r";
+    private static final String DEFAULT_IMAGE = "apache/spark:4.0.1-java17-r";
 
     @Schema(
         title = "The list of Spark CLI commands to run."

--- a/src/main/java/io/kestra/plugin/spark/SparkCLI.java
+++ b/src/main/java/io/kestra/plugin/spark/SparkCLI.java
@@ -91,7 +91,6 @@ public class SparkCLI extends AbstractExecScript implements RunnableTask<ScriptO
         if (rBeforeCommands.stream().noneMatch(c -> c.contains("export PATH")))
             rBeforeCommands = Stream.concat(Stream.of("export PATH=$PATH:/opt/spark/bin"), rBeforeCommands.stream()).toList();
 
-
         return this.commands(runContext)
             // spark set all logs in stdErr so we force all logs on info
             .withLogConsumer(new AbstractLogConsumer() {

--- a/src/main/java/io/kestra/plugin/spark/SparkCLI.java
+++ b/src/main/java/io/kestra/plugin/spark/SparkCLI.java
@@ -73,7 +73,7 @@ import jakarta.validation.constraints.NotNull;
     }
 )
 public class SparkCLI extends AbstractExecScript implements RunnableTask<ScriptOutput> {
-    private static final String DEFAULT_IMAGE = "apache/spark:4.0.1-java17-r";
+    private static final String DEFAULT_IMAGE = "apache/spark:4.0.1-java21-r";
 
     @Schema(
         title = "The list of Spark CLI commands to run."

--- a/src/test/java/io/kestra/plugin/spark/JarSubmitTest.java
+++ b/src/test/java/io/kestra/plugin/spark/JarSubmitTest.java
@@ -59,7 +59,6 @@ class JarSubmitTest {
             .master(Property.ofValue("spark://localhost:37077"))
             .runner(Property.ofValue(RunnerType.DOCKER))
             .docker(DockerOptions.builder()
-                .image("bitnami/spark:3.4.1")
                 .entryPoint(List.of(""))
                 .networkMode("host")
                 .user("root")

--- a/src/test/java/io/kestra/plugin/spark/PythonSubmitTest.java
+++ b/src/test/java/io/kestra/plugin/spark/PythonSubmitTest.java
@@ -41,7 +41,6 @@ class PythonSubmitTest {
             .master(Property.ofValue("spark://localhost:37077"))
             .runner(Property.ofValue(RunnerType.DOCKER))
             .docker(DockerOptions.builder()
-                .image("bitnami/spark:3.4.1")
                 .entryPoint(List.of(""))
                 .networkMode("host")
                 .user("root")


### PR DESCRIPTION
- closes #100 
- closes #45 

<img width="1151" height="165" alt="Screenshot 2025-10-08 at 11 18 25 AM" src="https://github.com/user-attachments/assets/de06a58b-9aa9-436b-aa0a-eb9d1c0230ee" />


### Contributor Checklist ✅


- [ ] PR Title and commits follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Add a `closes #ISSUE_ID` or `fixes #ISSUE_ID` in the description if the PR relates to an opened issue.
- [ ] Documentation updated (plugin docs from `@Schema` for properties and outputs, `@Plugin` with examples, `README.md` file with basic knowledge and specifics).
- [ ] Setup instructions included if needed (API keys, accounts, etc.).
- [ ] Prefix all rendered properties by `r` not `rendered` (eg: `rHost`).
- [ ] Use `runContext.logger()` to log enough important infos where it's needed and with the best level (DEBUG, INFO, WARN or ERROR).

⚙️ **Properties**
- [ ] Properties are declared with `Property<T>` carrier type, do **not** use `@PluginProperty`.
- [ ] Mandatory properties must be annotated with `@NotNull` and checked during the rendering.
- [ ] You can model a JSON thanks to a simple `Property<Map<String, Object>>`.

🌐 **HTTP**
- [ ] Must use Kestra’s internal HTTP client from `io.kestra.core.http.client`

📦 **JSON**
- [ ] If you are serializing response from an external API, you may have to add a `@JsonIgnoreProperties(ignoreUnknown = true)` at the mapped class level. So that we will avoid to crash the plugin if the provider add a new field suddenly.
- [ ] Must use Jackson mappers provided by core (`io.kestra.core.serializers`)

✨ **New plugins / subplugins**
- [ ] Make sure your new plugin is configured like mentioned [here](https://kestra.io/docs/plugin-developer-guide/gradle#mandatory-configuration).
- [ ] Add a `package-info.java` under each sub package respecting [this format](https://github.com/kestra-io/plugin-odoo/blob/main/src/main/java/io/kestra/plugin/odoo/package-info.java) and choosing the right category.
- [ ] Icons added in `src/main/resources/icons` in SVG format and not in thumbnail (keep it big):
  - `plugin-icon.svg`
  - One icon per package, e.g. `io.kestra.plugin.aws.svg`
  - For subpackages, e.g. `io.kestra.plugin.aws.s3`, add `io.kestra.plugin.aws.s3.svg`
    See example [here](https://github.com/kestra-io/plugin-elasticsearch/blob/master/src/main/java/io/kestra/plugin/elasticsearch/Search.java#L76).
- [ ] Use `"{{ secret('YOUR_SECRET') }}"` in the examples for sensible infos such as an API KEY.
- [ ] If you are fetching data (one, many or too many), you must add a `Property<FetchType> fetchType` to be able to use `FETCH_ONE`, `FETCH` and even `STORE` to store big amount of data in the internal storage.
- [ ] Align the `"""` to close examples blocks with the flow id.

🧪 **Tests**
- [ ] Unit Tests added or updated to cover the change (using the `RunContext` to actually run tasks).
- [ ] Add sanity checks if possible with a YAML flow inside `src/test/resources/flows`.
- [ ] Avoid disabling tests for CI. Instead, configure a local environment whenever it's possible with `.github/setup-unit.sh` (which can be executed locally and in the CI) all along with a new `docker-compose-ci.yml` file (do **not** edit the existing `docker-compose.yml`).
- [ ] Provide screenshots from your QA / tests locally in the PR description. The goal here is to use the JAR of the plugin and directly test it locally in Kestra UI to ensure it integrates well.

📤 **Outputs**
- [ ] Do not send back as outputs the same infos you already have in your properties.
- [ ] If you do not have any output use `VoidOutput`.
- [ ] Do not output twice the same infos (eg: a status code, an error code saying the same thing...).
