### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     annotationProcessor group: "io.kestra", name: "processor", version: kestraVersion
 
     // Spark lib: must be aligned with the docker-compose-ci.yaml files and the image used in test
-    api group: 'org.apache.spark', name: 'spark-launcher_2.13', version: '4.2.0-preview5'
+    api group: 'org.apache.spark', name: 'spark-launcher_2.13', version: '4.0.1'
     compileOnly group: "io.kestra", name: "script", version: kestraVersion
 }
 

--- a/src/main/java/io/kestra/plugin/spark/AbstractSubmit.java
+++ b/src/main/java/io/kestra/plugin/spark/AbstractSubmit.java
@@ -201,8 +201,7 @@ public abstract class AbstractSubmit extends Task implements RunnableTask<Script
             .withDockerOptions(injectDefaults(this.getDocker()))
             .withTaskRunner(this.taskRunner)
             .withContainerImage(this.containerImage)
-            .withInterpreter(Property.ofValue(List.of("/bin/sh", "-c")))
-            .withCommands(Property.ofValue(List.of(String.join(" ", commandsArgs))))
+            .withCommands(Property.ofValue(commandsArgs))
             .run();
     }
 


### PR DESCRIPTION
## Summary

Remediates all findings (CRITICAL/HIGH/MEDIUM/LOW) from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **HIGH** — Shell injection via unsanitized user-controlled arguments passed to `/bin/sh -c` (CWE-78 / OWASP A03:2021) — `src/main/java/io/kestra/plugin/spark/AbstractSubmit.java:205`. Removed the `/bin/sh -c` interpreter layer and the unsafe `String.join(" ", commandsArgs)` shell-string construction; `CommandsWrapper` now receives the argument list as individual tokens, so shell metacharacters in user-controlled fields (`master`, `sparkSubmitPath`, `configurations`, `appFiles`, `name`, etc.) are no longer interpreted by a shell.
- **LOW** — Non-stable preview dependency: `spark-launcher_2.13:4.2.0-preview4` — `build.gradle:59`. Pinned to the stable `4.0.1` release, aligned with the `apache/spark:4.0.1-java21-r` image already used in `docker-compose-ci.yml`, removing the supply-chain risk of depending on a non-stable preview artifact.

(MEDIUM section of the audit EPIC reported no findings.)

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-spark/issues/159
- [Full Audit Report](https://claude.ai/code/artifact/87ba8c38-c7ec-40ef-8d8e-384da1bfacf4)
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)
